### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-shutil
 tkinter
-os
 win32api
 pyinstaller


### PR DESCRIPTION
Remove standard library packages (os and shutil) from requirements.txt. Requirements.txt does not work when standard library packages are included.